### PR TITLE
OPSEXP-1463 Update to ActiveMQ 5.17.1 for vuln

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,9 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,11 @@ jobs:
         jdist:
           - jre
         activemq_version:
+          - 5.16.5
           - 5.17.1
+        exclude:
+          - java_major: 17
+            activemq_version: 5.16.5
     runs-on: ubuntu-latest
     needs: pre-commit
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
     needs: pre-commit
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
       - id: vars
         name: Compute Image Tag
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
       - uses: pre-commit/action@v2.0.3
   docker:
     strategy:
@@ -27,19 +27,17 @@ jobs:
             major: 8
         java_major:
           - 11
+          - 17
         jdist:
           - jre
         activemq_version:
-          - 5.16.4
-          - 5.17.0
+          - 5.17.1
     runs-on: ubuntu-latest
     needs: pre-commit
     steps:
-      - id: co
-        name: checkout project
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: vars
-        name: compute image tag
+        name: Compute Image Tag
         env:
           IMAGE_BASE_NAME: ${{ matrix.activemq_version }}-${{ matrix.jdist }}${{ matrix.java_major }}-${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}
         run: |
@@ -54,23 +52,19 @@ jobs:
           fi
           echo "::set-output name=image_created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           echo "::set-output name=image_anchor::$(date -u +'%Y%m%d%H%M')"
-      - id: q_login
-        name: Login to Quay.io
-        uses: docker/login-action@v1
+      - name: Login to quay.io
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - id: dh_login
-        if: contains(github.event.head_commit.message, '[release]') && github.ref_name == 'master'
-        name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to docker.io
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - id: q_push
-        name: Build and push to Quay.io
-        uses: docker/build-push-action@v2.8.0
+      - name: Build and push to quay.io
+        uses: docker/build-push-action@v3
         with:
           push: true
           build-args: |
@@ -86,22 +80,12 @@ jobs:
             quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.image_anchor }}
             quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
           target: ACTIVEMQ_IMAGE
-      - id: dh_push
+          platforms: linux/amd64,linux/arm64/v8
+      - name: Push Image to docker.io
         if: contains(github.event.head_commit.message, '[release]') && github.ref_name == 'master'
-        name: Build and push to Docker Hub
-        uses: docker/build-push-action@v2.8.0
+        uses: akhilerm/tag-push-action@v2.0.0
         with:
-          push: true
-          build-args: |
-            no-cache=true
-            JDIST=${{ matrix.jdist }}
-            DISTRIB_NAME=${{ matrix.base_image.flavor }}
-            DISTRIB_MAJOR=${{ matrix.base_image.major }}
-            JAVA_MAJOR=${{ matrix.java_major }}
-            REVISION=${{ github.run_number }}
-            REVISION=${{ github.run_number }}
-            CREATED=${{ steps.vars.outputs.image_created }}
-          tags: |
+          src: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.image_anchor }}
+          dst: |
             ${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.image_anchor }}
             ${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
-          target: ACTIVEMQ_IMAGE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
     needs: pre-commit
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - id: vars
         name: Compute Image Tag


### PR DESCRIPTION
* update AMQ to 5.17.1 to fix spring vulnerabilities
* remove AMQ 5.16.x with reload4j and not being updated anymore https://activemq.apache.org/activemq-5016005-release
* add support for multi-arch and Java 17 from upstream

Ref. OPSEXP-1463 