### PR TITLE
OPSEXP-2186 Release on every master push with semver and shorter tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - OPSEXP-2186-fixup-release-and-expire
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push to quay.io
+      - name: Build and push
         uses: docker/build-push-action@v4
         with:
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - OPSEXP-2186-fixup-release-and-expire
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,18 +50,14 @@ jobs:
 
           TAG_BASE_NAME="$ACTIVEMQ_VERSION-${{ matrix.jdist }}${{ matrix.java_major }}-${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}"
 
-          if [[ "${{ github.ref_name }}" != "master" ]]
-          then
+          if [[ "${{ github.ref_name }}" != "master" ]]; then
             echo "image_tag=${TAG_BASE_NAME}-${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
             echo "labels=quay.expires-after=1d" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.head_commit.message }}" =~ .*\[release\].* ]]
-          then
-            echo "image_tag=$TAG_BASE_NAME" >> $GITHUB_OUTPUT
           else
-            echo "image_tag=${TAG_BASE_NAME}-release-candidate" >> $GITHUB_OUTPUT
+            echo "image_tag=$TAG_BASE_NAME" >> $GITHUB_OUTPUT
           fi
+
           echo "image_created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-          echo "image_anchor=$(date -u +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
 
       - name: Login to quay.io
         uses: docker/login-action@v2
@@ -69,12 +65,6 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Login to docker.io
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push to quay.io
         uses: docker/build-push-action@v4
@@ -90,7 +80,6 @@ jobs:
             REVISION=${{ github.run_number }}
             CREATED=${{ steps.vars.outputs.image_created }}
           tags: |
-            quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.image_anchor }}
             quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
           labels: |
             ${{ steps.vars.outputs.labels }}
@@ -98,11 +87,17 @@ jobs:
           target: ACTIVEMQ_IMAGE
           platforms: linux/amd64,linux/arm64/v8
 
+      - name: Login to docker.io
+        if: github.ref_name == 'master'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Push Image to docker.io
-        if: contains(github.event.head_commit.message, '[release]') && github.ref_name == 'master'
+        if: github.ref_name == 'master'
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.image_anchor }}
+          src: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
           dst: |
-            ${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.image_anchor }}
             ${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
           - 5.16
           - 5.17
           - 5.18
+    env:
+      # Which activemq_base_version of the matrix should produce `latest` tag
+      ACTIVEMQ_LATEST_VERSION: 5.18
     runs-on: ubuntu-latest
     needs: pre-commit
     steps:
@@ -70,6 +73,10 @@ jobs:
             echo "${QUAY_IMAGE_NAME}:${IMAGE_TAG_MINOR}" >> $GITHUB_OUTPUT
             echo "${DOCKERHUB_IMAGE_NAME}:${IMAGE_TAG_SEMVER}" >> $GITHUB_OUTPUT
             echo "${DOCKERHUB_IMAGE_NAME}:${IMAGE_TAG_MINOR}" >> $GITHUB_OUTPUT
+            if [ "${ACTIVEMQ_BASE_VERSION}" == "$ACTIVEMQ_LATEST_VERSION" ]; then
+              echo "${QUAY_IMAGE_NAME}:latest" >> $GITHUB_OUTPUT
+              echo "${DOCKERHUB_IMAGE_NAME}:latest" >> $GITHUB_OUTPUT
+            fi
             echo "EOF" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,5 +112,3 @@ jobs:
           provenance: false
           target: ACTIVEMQ_IMAGE
           platforms: linux/amd64,linux/arm64/v8
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Login to docker.io
-        if: github.ref_name == 'master'
+        if: github.event_name == 'push'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,21 +43,34 @@ jobs:
       - uses: docker/setup-buildx-action@v2
 
       - id: vars
-        name: Compute Image Tag
+        name: Compute vars
+        env:
+          ACTIVEMQ_BASE_VERSION: ${{ matrix.activemq_base_version }}
         run: |
-          ACTIVEMQ_VERSION=$(jq -r .activemq_version versions/activemq-${{ matrix.activemq_base_version }}.json)
+          ACTIVEMQ_VERSION=$(jq -r .activemq_version versions/activemq-${ACTIVEMQ_BASE_VERSION}.json)
           echo "activemq_version=$ACTIVEMQ_VERSION" >> $GITHUB_OUTPUT
-
-          TAG_BASE_NAME="${{ matrix.activemq_base_version }}-${{ matrix.jdist }}${{ matrix.java_major }}-${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}"
-
-          if [[ "${{ github.ref_name }}" != "master" ]]; then
-            echo "image_tag=${TAG_BASE_NAME}-${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
-            echo "labels=quay.expires-after=1d" >> $GITHUB_OUTPUT
-          else
-            echo "image_tag=$TAG_BASE_NAME" >> $GITHUB_OUTPUT
-          fi
-
           echo "image_created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+          QUAY_IMAGE_NAME="quay.io/${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}"
+          DOCKERHUB_IMAGE_NAME="${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}"
+          TAG_COMMON_METADATA="${{ matrix.jdist }}${{ matrix.java_major }}-${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}"
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "labels=quay.expires-after=1d" >> $GITHUB_OUTPUT
+
+            IMAGE_TAG_PR="${ACTIVEMQ_VERSION}-${TAG_COMMON_METADATA}-pr-${{ github.event.pull_request.number}}"
+            echo "tags=${QUAY_IMAGE_NAME}:${IMAGE_TAG_PR}" >> $GITHUB_OUTPUT
+          else
+            IMAGE_TAG_SEMVER="${ACTIVEMQ_VERSION}-${TAG_COMMON_METADATA}"
+            IMAGE_TAG_MINOR="${ACTIVEMQ_BASE_VERSION}-${TAG_COMMON_METADATA}"
+
+            echo "tags<<EOF" >> $GITHUB_OUTPUT
+            echo "${QUAY_IMAGE_NAME}:${IMAGE_TAG_SEMVER}" >> $GITHUB_OUTPUT
+            echo "${QUAY_IMAGE_NAME}:${IMAGE_TAG_MINOR}" >> $GITHUB_OUTPUT
+            echo "${DOCKERHUB_IMAGE_NAME}:${IMAGE_TAG_SEMVER}" >> $GITHUB_OUTPUT
+            echo "${DOCKERHUB_IMAGE_NAME}:${IMAGE_TAG_MINOR}" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
 
       - name: Login to quay.io
         uses: docker/login-action@v2
@@ -66,12 +79,18 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Login to docker.io
+        if: github.ref_name == 'master'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build and push to quay.io
         uses: docker/build-push-action@v4
         with:
           push: true
           build-args: |
-            no-cache=true
             ACTIVEMQ_VERSION=${{ steps.vars.outputs.activemq_version }}
             JDIST=${{ matrix.jdist }}
             DISTRIB_NAME=${{ matrix.base_image.flavor }}
@@ -80,24 +99,11 @@ jobs:
             REVISION=${{ github.run_number }}
             CREATED=${{ steps.vars.outputs.image_created }}
           tags: |
-            quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
+            ${{ steps.vars.outputs.tags }}
           labels: |
             ${{ steps.vars.outputs.labels }}
           provenance: false
           target: ACTIVEMQ_IMAGE
           platforms: linux/amd64,linux/arm64/v8
-
-      - name: Login to docker.io
-        if: github.ref_name == 'master'
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push Image to docker.io
-        if: github.ref_name == 'master'
-        uses: akhilerm/tag-push-action@v2.1.0
-        with:
-          src: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
-          dst: |
-            ${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           ACTIVEMQ_VERSION=$(jq -r .activemq_version versions/activemq-${{ matrix.activemq_base_version }}.json)
           echo "activemq_version=$ACTIVEMQ_VERSION" >> $GITHUB_OUTPUT
 
-          TAG_BASE_NAME="$ACTIVEMQ_VERSION-${{ matrix.jdist }}${{ matrix.java_major }}-${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}"
+          TAG_BASE_NAME="${{ matrix.activemq_base_version }}-${{ matrix.jdist }}${{ matrix.java_major }}-${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}"
 
           if [[ "${{ github.ref_name }}" != "master" ]]; then
             echo "image_tag=${TAG_BASE_NAME}-${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,26 @@ ARG JDIST
 ARG JAVA_MAJOR
 ARG DISTRIB_NAME
 ARG DISTRIB_MAJOR
+ARG ACTIVEMQ_VERSION
 
 FROM alfresco/alfresco-base-java:${JDIST}${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR} as ACTIVEMQ_IMAGE
 
 LABEL org.label-schema.schema-version="1.0" \
-	org.label-schema.name="Alfresco ActiveMQ" \
-	org.label-schema.vendor="Alfresco" \
-	org.label-schema.build-date="$CREATED" \
-	org.opencontainers.image.title="Alfresco ActiveMQ" \
-	org.opencontainers.image.vendor="Alfresco" \
-	org.opencontainers.image.revision="$REVISION" \
-	org.opencontainers.image.source="https://github.com/Alfresco/alfresco-docker-activemq" \
-	org.opencontainers.image.created="$CREATED"
+    org.label-schema.name="Alfresco ActiveMQ" \
+    org.label-schema.vendor="Alfresco" \
+    org.label-schema.build-date="$CREATED" \
+    org.opencontainers.image.title="Alfresco ActiveMQ" \
+    org.opencontainers.image.vendor="Alfresco" \
+    org.opencontainers.image.revision="$REVISION" \
+    org.opencontainers.image.source="https://github.com/Alfresco/alfresco-docker-activemq" \
+    org.opencontainers.image.created="$CREATED" \
+    org.opencontainers.image.version="$ACTIVEMQ_VERSION"
 
 # Set default user information
 ARG GROUPNAME=Alfresco
 ARG GROUPID=1000
 ARG USERNAME=amq
 ARG USERID=33031
-ARG ACTIVEMQ_VERSION=5.16.4
 
 ENV ACTIVEMQ_HOME="/opt/activemq"
 ENV ACTIVEMQ_BASE="/opt/activemq"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ ARG JDIST
 ARG JAVA_MAJOR
 ARG DISTRIB_NAME
 ARG DISTRIB_MAJOR
-ARG ACTIVEMQ_VERSION
 
 FROM alfresco/alfresco-base-java:${JDIST}${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR} as ACTIVEMQ_IMAGE
+
+ARG ACTIVEMQ_VERSION
 
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.name="Alfresco ActiveMQ" \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Alfresco ActiveMQ docker image
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/Alfresco/alfresco-docker-activemq/build.yml?branch=master)](https://github.com/Alfresco/alfresco-docker-activemq/actions/workflows/build.yml)
+![5.18-jre17-rockylinux8](https://img.shields.io/docker/v/alfresco/alfresco-activemq/latest)
+![5.17-jre17-rockylinux8](https://img.shields.io/docker/v/alfresco/alfresco-activemq/5.17-jre17-rockylinux8)
+![5.16-jre17-rockylinux8](https://img.shields.io/docker/v/alfresco/alfresco-activemq/5.16-jre17-rockylinux8)
 
 This repository contains the Dockerfile used to create the Alfresco ActiveMQ
 image that will be used by Alfresco engineering teams, other internal groups in

--- a/README.md
+++ b/README.md
@@ -9,24 +9,31 @@ Platform.
 
 ## Quickstart
 
-Choose between one of the available flavours built from this repository:
+Multiple tags are available depending on the versions/flavours:
 
 Activemq version | Java version | OS           | Image tag                | Size
 -----------------|--------------|--------------|--------------------------|----------------
-5.16             | 17           | Rockylinux 8 | 5.16-jre17-rockylinux8 | ![5.16 size][1]
-5.17             | 17           | Rockylinux 8 | 5.17-jre17-rockylinux8 | ![5.17 size][2]
-5.18             | 17           | Rockylinux 8 | 5.18-jre17-rockylinux8 | ![5.18 size][3]
+5.16             | 17           | Rockylinux 8 | `5.16-jre17-rockylinux8` | ![5.16 size][1]
+5.17             | 17           | Rockylinux 8 | `5.17-jre17-rockylinux8` | ![5.17 size][2]
+5.18             | 17           | Rockylinux 8 | `5.18-jre17-rockylinux8` | ![5.18 size][3]
 
 [1]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.16-jre17-rockylinux8
 [2]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.17-jre17-rockylinux8
 [3]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.18-jre17-rockylinux8
 
-* [Docker Hub](https://hub.docker.com/r/alfresco/alfresco-activemq) image name: `alfresco/alfresco-activemq`
-* [Quay](https://quay.io/repository/alfresco/alfresco-activemq) image name: `quay.io/alfresco/alfresco-activemq`
+> Additional tags available:
+>
+> * `5.18.NN-jre17-rockylinux8` (full semver)
+> * `latest` which always point to the latest activemq version available
+
+Built images are available on the following registries:
+
+* [Docker Hub](https://hub.docker.com/r/alfresco/alfresco-activemq) as `alfresco/alfresco-activemq`
+* [Quay](https://quay.io/repository/alfresco/alfresco-activemq) as `quay.io/alfresco/alfresco-activemq` (requires authentication)
 
 Example final image: `alfresco/alfresco-activemq:5.18-jre17-rockylinux8`
 
-> If you are using this base image in a public repository, please stick to the Docker Hub published image.
+> If you are using this image in a public repository, please stick to the Docker Hub published image.
 
 ### Image pinning
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Example final image: `alfresco/alfresco-activemq:5.18-jre17-rockylinux8`
 
 > If you are using this base image in a public repository, please stick to the Docker Hub published image.
 
+### Image pinning
+
+The [pinning suggestions provided in alfresco-base-java](https://github.com/Alfresco/alfresco-docker-base-java/blob/master/README.md#image-pinning) are valid for this image too.
+
 ## Configuration parameters
 
 The following can be set via environment variables:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 ![5.17-jre17-rockylinux8](https://img.shields.io/docker/v/alfresco/alfresco-activemq/5.17-jre17-rockylinux8)
 ![5.16-jre17-rockylinux8](https://img.shields.io/docker/v/alfresco/alfresco-activemq/5.16-jre17-rockylinux8)
 
-This repository contains the Dockerfile used to create the Alfresco ActiveMQ
-image that will be used by Alfresco engineering teams, other internal groups in
-the organisation, customers and partners to run the Alfresco Digital Business
-Platform.
+This repository produces multi-arch ActiveMQ images compatible with all the
+supported Alfresco versions that will be used by Alfresco engineering teams,
+other internal groups in the organisation, customers and partners to run the
+Alfresco Digital Business Platform.
 
 ## Quickstart
 
@@ -37,6 +37,8 @@ Built images are available on the following registries:
 Example final image: `alfresco/alfresco-activemq:5.18-jre17-rockylinux8`
 
 > If you are using this image in a public repository, please stick to the Docker Hub published image.
+
+Images are built for `amd64` and `arm64` architectures.
 
 ### Image pinning
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Activemq version | Java version | OS           | Image tag                | Size
 [2]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.17-jre17-rockylinux8
 [3]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.18-jre17-rockylinux8
 
-> Additional tags available:
->
-> * `5.18.NN-jre17-rockylinux8` (full semver)
-> * `latest` which always point to the latest activemq version available
+Additional tags available:
+
+* `5.18.NN-jre17-rockylinux8` (full semver)
+* `latest` which always point to the latest activemq version available
 
 Built images are available on the following registries:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
-# Welcome to Alfresco ActiveMQ docker image
+# Alfresco ActiveMQ docker image
 
-## Introduction
+[![Build Status](https://img.shields.io/github/actions/workflow/status/Alfresco/alfresco-docker-activemq/build.yml?branch=master)](https://github.com/Alfresco/alfresco-docker-activemq/actions/workflows/build.yml)
 
-This repository contains the Dockerfile used to create the Alfresco ActiveMQ image that
-will be used by Alfresco engineering teams, other internal groups in the
-organisation, customers and partners to run the Alfresco Digital Business Platform.
+This repository contains the Dockerfile used to create the Alfresco ActiveMQ
+image that will be used by Alfresco engineering teams, other internal groups in
+the organisation, customers and partners to run the Alfresco Digital Business
+Platform.
 
-## Configuration parameters:
+## Quickstart
+
+Choose between one of the available flavours built from this repository:
+
+Activemq version | Java version | OS           | Image tag                | Size
+-----------------|--------------|--------------|--------------------------|----------------
+5.16             | 17           | Rockylinux 8 | 5.16-jre17-rockylinux8 | ![5.16 size][1]
+5.17             | 17           | Rockylinux 8 | 5.17-jre17-rockylinux8 | ![5.17 size][2]
+5.18             | 17           | Rockylinux 8 | 5.18-jre17-rockylinux8 | ![5.18 size][3]
+
+[1]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.16-jre17-rockylinux8
+[2]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.17-jre17-rockylinux8
+[3]: https://img.shields.io/docker/image-size/alfresco/alfresco-activemq/5.18-jre17-rockylinux8
+
+* [Docker Hub](https://hub.docker.com/r/alfresco/alfresco-activemq) image name: `alfresco/alfresco-activemq`
+* [Quay](https://quay.io/repository/alfresco/alfresco-activemq) image name: `quay.io/alfresco/alfresco-activemq`
+
+Example final image: `alfresco/alfresco-activemq:5.18-jre17-rockylinux8`
+
+> If you are using this base image in a public repository, please stick to the Docker Hub published image.
+
+## Configuration parameters
+
 The following can be set via environment variables:
 
 | Parameter               | Default value | Description                                          |


### PR DESCRIPTION
Ref: OPSEXP-2186

* Push only one tag to workaround quay expire label bug during PR (no more `-202307241204` tags which seems never really used across the org)
* Push a new tag without bugfix version so people will always fetch the latest bugfix version
* Push a `latest` tag for the greater activemq version
* Provide the full activemq version (including bugfix) as an image label
* Provides docs for available tags and image pinning instructions