### PR TITLE
Ensure apache archive is ready before updating versions

### DIFF
--- a/updatecli.d/activemq_bugfix_version.tpl
+++ b/updatecli.d/activemq_bugfix_version.tpl
@@ -19,6 +19,13 @@ sources:
     transformers:
       - trimprefix: "activemq-"
 
+conditions:
+  archiveReady:
+    kind: file
+    sourceid: activemqTag
+    spec:
+      file: https://archive.apache.org/dist/activemq/{{ source `activemqTag` }}/apache-activemq-{{ source `activemqTag` }}-bin.tar.gz
+
 targets:
   activemqJson:
     name: Update version in json target


### PR DESCRIPTION
Add condition to updatecli manifest to prevent raising a not ready bump